### PR TITLE
Implement dump of chip via SPI

### DIFF
--- a/include/MtcaProgrammerBase.h
+++ b/include/MtcaProgrammerBase.h
@@ -51,6 +51,7 @@ class MtcaProgrammerBase {
   virtual void erase() = 0;
   virtual void program(std::string firmwareFile) = 0;
   virtual bool verify(std::string firmwareFile) = 0;
+  virtual bool dump(std::string firmwareFile, uint32_t imageSize) = 0;
   virtual void rebootFPGA() = 0;
 
  protected:

--- a/include/MtcaProgrammerJTAG.h
+++ b/include/MtcaProgrammerJTAG.h
@@ -23,6 +23,7 @@ class MtcaProgrammerJTAG : public MtcaProgrammerBase, XSVFPlayerInterface {
   void erase();
   void program(std::string firmwareFile);
   bool verify(std::string firmwareFile);
+  bool dump(std::string firmwareFile, uint32_t imageSize);
   void rebootFPGA();
 
   // XSVFPlayerInterface

--- a/include/MtcaProgrammerSPI.h
+++ b/include/MtcaProgrammerSPI.h
@@ -32,6 +32,7 @@ class MtcaProgrammerSPI : public MtcaProgrammerBase {
   void erase();
   void program(std::string firmwareFile);
   bool verify(std::string firmwareFile);
+  bool dump(std::string firmwareFile, uint32_t imageSize);
   void rebootFPGA();
 
  private:

--- a/src/MtcaProgrammerJTAG.cpp
+++ b/src/MtcaProgrammerJTAG.cpp
@@ -72,6 +72,12 @@ bool MtcaProgrammerJTAG::verify(std::string) {
   return true;
 }
 
+/* not implemented */
+bool MtcaProgrammerJTAG::dump(std::string, uint32_t) {
+  printf("\nFirmware dump via JTAG is not implemented\n");
+  return false;
+}
+
 void MtcaProgrammerJTAG::rebootFPGA() {
   printf("FPGA rebooting...\n");
   reg_rev_switch = FPGA_REBOOT_WORD;


### PR DESCRIPTION
The tool can already read the SPI flash chip contents for verification, but it only compares it byte by byte with a local file and discards the read data.

This commit reuses the verification function for a new dumping function. The user specifies the dump action parameter (--dump or -m), a filename to write to (e.g. "-f dump.bin"), and the size of the chip in bytes (e.g. "-s 1048576" for a 1 MiB aka 8M chip).