### PR TITLE
Revert "Increase required DeviceAccess version (#10)"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ INCLUDE(${CMAKE_SOURCE_DIR}/cmake/set_default_build_to_release.cmake)
 INCLUDE(${CMAKE_SOURCE_DIR}/cmake/set_default_flags.cmake)
 
 include(cmake/add_dependency.cmake)
-add_dependency(ChimeraTK-DeviceAccess 03.09 REQUIRED)
+add_dependency(ChimeraTK-DeviceAccess 03.08 REQUIRED)
 add_dependency(Boost 1.46 program_options REQUIRED)
 
 include(cmake/enable_code_style_check.cmake)


### PR DESCRIPTION
This reverts commit a7d0bcf5d3e143a9462fb916e025aa48d60febaf.

The commit was based on false assumptions. The newer DeviceAccess
version is not necessary, since the required changes are already in the
previous required version (which has been just released).
