### PR TITLE
Adding AFCv4 SPI to known proms

### DIFF
--- a/src/MtcaProgrammerSPI.cpp
+++ b/src/MtcaProgrammerSPI.cpp
@@ -27,7 +27,7 @@ const std::map<uint64_t, memory_info_t> MtcaProgrammerSPI::known_proms = {
     {0x00001770EF, {PROM_ADDR_24B, QUAD_MODE_DIS}}, // SIS8300L2
     {0x20C21920C2, {PROM_ADDR_24B, QUAD_MODE_DIS}}, // SIS8300KU
     {0x0010172020, {PROM_ADDR_24B, QUAD_MODE_EN}},  // PiezoBox (M25P64)
-    {0x441019BA20, {PROM_ADDR_24B, QUAD_MODE_DIS}}, // AFCv4 (Micron MT25QL256ABA8ESF)
+    {0x441019BA20, {PROM_ADDR_24B, QUAD_MODE_DIS}}  // AFCv4 (Micron MT25QL256ABA8ESF)
 };
 /**********************************************************************************************************************/
 

--- a/src/MtcaProgrammerSPI.cpp
+++ b/src/MtcaProgrammerSPI.cpp
@@ -26,7 +26,8 @@ const std::map<uint64_t, memory_info_t> MtcaProgrammerSPI::known_proms = {
     {0x00001740EF, {PROM_ADDR_24B, QUAD_MODE_DIS}}, // SIS8300L
     {0x00001770EF, {PROM_ADDR_24B, QUAD_MODE_DIS}}, // SIS8300L2
     {0x20C21920C2, {PROM_ADDR_24B, QUAD_MODE_DIS}}, // SIS8300KU
-    {0x0010172020, {PROM_ADDR_24B, QUAD_MODE_EN}}   // PiezoBox (M25P64)
+    {0x0010172020, {PROM_ADDR_24B, QUAD_MODE_EN}},  // PiezoBox (M25P64)
+    {0x441019BA20, {PROM_ADDR_24B, QUAD_MODE_DIS}}, // AFCv4 (Micron MT25QL256ABA8ESF)
 };
 /**********************************************************************************************************************/
 


### PR DESCRIPTION
This patch adds support for OHWR AFC v4 AMC (2 FMC carrier with Artix7), see https://ohwr.org/projects/afc/ .
Flashing worked successfully. It's possible that a quirk in the 256MBit PROM (Micron MT25QL256ABA8ESF) limits the accessible size to 128MBit.